### PR TITLE
feat(marketing): add script for sending marketing events from csv data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.env
 .keys
 build
 data.stage
 lambda.zip
 node_modules
+npm-debug.log
 *.parquet

--- a/marketing.js
+++ b/marketing.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 const Promise = require('bluebird')
 const request = require('request-promise')
 const s3 = require('s3')
-const moment = require('moment')
+const moment = require('moment-timezone')
 
 fs.unlinkAsync = Promise.promisify(fs.unlink)
 
@@ -145,7 +145,7 @@ function getEventType (row) {
 }
 
 function getTime (row) {
-  const time = moment(row.EventDate, 'MMM D YYYY  H:mmA')
+  const time = moment.tz(row.EventDate, 'MMM D YYYY  H:mmA', 'America/Los_Angeles')
   if (time.isValid()) {
     return time.unix()
   }

--- a/marketing.js
+++ b/marketing.js
@@ -7,6 +7,7 @@ const fs = require('fs')
 const Promise = require('bluebird')
 const request = require('request-promise')
 const s3 = require('s3')
+const moment = require('moment')
 
 fs.unlinkAsync = Promise.promisify(fs.unlink)
 
@@ -137,15 +138,16 @@ function createEvent (row) {
 
 function getEventType (row) {
   const eventParts = EVENT.exec(row.Event)
+
   if (eventParts && eventParts.length === 2) {
     return eventParts[1]
   }
 }
 
 function getTime (row) {
-  const time = Date.parse(row.EventDate)
-  if (! isNaN(time)) {
-    return Math.round(time / 1000)
+  let time = moment(row.EventDate, 'MMM D YYYY  H:mmA')
+  if (time.isValid()) {
+    return time.unix();
   }
 }
 

--- a/marketing.js
+++ b/marketing.js
@@ -140,7 +140,7 @@ function getEventType (row) {
   const eventParts = EVENT.exec(row.Event)
 
   if (eventParts && eventParts.length === 2) {
-    return eventParts[1]
+    return eventParts[1].replace(/-/g, '_')
   }
 }
 

--- a/marketing.js
+++ b/marketing.js
@@ -8,7 +8,7 @@ const Promise = require('bluebird')
 const request = require('request-promise')
 const s3 = require('s3')
 const moment = require('moment-timezone')
-const {lookup} = require('lookup-dns-cache')
+const { lookup } = require('lookup-dns-cache')
 
 fs.unlinkAsync = Promise.promisify(fs.unlink)
 
@@ -189,7 +189,7 @@ function getEventProperties (row) {
 function sendBatch (batch) {
   return request('https://api.amplitude.com/httpapi', {
     method: 'POST',
-    lookup: lookup,
+    lookup,
     formData: {
       api_key: API_KEY,
       event: JSON.stringify(batch)

--- a/marketing.js
+++ b/marketing.js
@@ -11,7 +11,7 @@ const s3 = require('s3')
 fs.unlinkAsync = Promise.promisify(fs.unlink)
 
 const TIMESTAMP = /^(20[1-9][0-9])-([01][0-9])-([0-3][1-9])-([0-2][0-9])-([0-5][0-9])$/
-const EVENT = /^mktg-([a-z]+_[a-z]+)$/
+const EVENT = /^mktg-([a-z]+-[a-z]+)$/
 
 const AWS_ACCESS_KEY = process.env.FXA_AWS_ACCESS_KEY
 const AWS_SECRET_KEY = process.env.FXA_AWS_SECRET_KEY

--- a/marketing.js
+++ b/marketing.js
@@ -128,9 +128,9 @@ function createEvent (row) {
   return {
     event_type: `mktg - ${eventType}`,
     time,
-    user_id,
+    user_id: hash(user_id),
     session_id: -1,
-    insert_id: getInsertId(user_id, eventType, time, email_id),
+    insert_id: hash(user_id, eventType, time, email_id),
     event_properties: getEventProperties(row)
   }
 }
@@ -149,7 +149,7 @@ function getTime (row) {
   }
 }
 
-function getInsertId (...properties) {
+function hash (...properties) {
   const hmac = crypto.createHmac('sha256', HMAC_KEY)
 
   properties.forEach(property => hmac.update(`${property}`))

--- a/marketing.js
+++ b/marketing.js
@@ -8,6 +8,7 @@ const Promise = require('bluebird')
 const request = require('request-promise')
 const s3 = require('s3')
 const moment = require('moment-timezone')
+const {lookup} = require('lookup-dns-cache')
 
 fs.unlinkAsync = Promise.promisify(fs.unlink)
 
@@ -188,6 +189,7 @@ function getEventProperties (row) {
 function sendBatch (batch) {
   return request('https://api.amplitude.com/httpapi', {
     method: 'POST',
+    lookup: lookup,
     formData: {
       api_key: API_KEY,
       event: JSON.stringify(batch)

--- a/marketing.js
+++ b/marketing.js
@@ -38,10 +38,6 @@ if (! HMAC_KEY || ! API_KEY) {
 }
 
 processData()
-  .then(count => {
-    console.log(`Sent ${count} events!`)
-    process.exit(0)
-  })
   .catch(error => {
     console.error(error.stack)
     process.exit(1)
@@ -66,6 +62,10 @@ function processData () {
 function processStream (stream) {
   let eventCount = 0, batch = [], error
 
+  process.on('exit', () => {
+    console.log(`Sent ${eventCount} events!`)
+  })
+
   return new Promise((resolve, reject) => {
     stream
       .pipe(new AutoDetectDecoderStream())
@@ -84,7 +84,7 @@ function processStream (stream) {
 
         const localBatch = batch.slice()
         batch = []
-        send(localBatch).catch(() => {})
+        send(localBatch).catch(reject)
       })
       .on('end', () => {
         if (error) {

--- a/marketing.js
+++ b/marketing.js
@@ -1,0 +1,227 @@
+'use strict'
+
+const AutoDetectDecoderStream = require('autodetect-decoder-stream')
+const crypto = require('crypto')
+const csv = require('csv-parser')
+const fs = require('fs')
+const Promise = require('bluebird')
+const request = require('request-promise')
+const s3 = require('s3')
+
+fs.unlinkAsync = Promise.promisify(fs.unlink)
+
+const TIMESTAMP = /^(20[1-9][0-9])-([01][0-9])-([0-3][1-9])-([0-2][0-9])-([0-5][0-9])$/
+const EVENT = /^mktg-([a-z]+_[a-z]+)$/
+
+const AWS_ACCESS_KEY = process.env.FXA_AWS_ACCESS_KEY
+const AWS_SECRET_KEY = process.env.FXA_AWS_SECRET_KEY
+const AWS_S3_BUCKET = '*** TODO ***'
+const AWS_S3_PREFIX = '*** TODO ***'
+
+const MAX_EVENTS_PER_BATCH = 10
+const HMAC_KEY = process.env.FXA_AMPLITUDE_HMAC_KEY
+const API_KEY = process.env.FXA_AMPLITUDE_API_KEY
+
+if (process.argv.length !== 3) {
+  console.error(`Usage: ${process.argv[1]} {YYYY-MM-DD-hh-mm | LOCAL PATH}`)
+  console.error('If specifying YYYY-MM-DD-hh-mm as the arg, note that the script will try to send events')
+  console.error('for all times from YYYY-MM-DD-hh-mm to the most recent available in S3. If any times in')
+  console.error('that range are missing, they will be skipped without failing the process.')
+  process.exit(1)
+}
+
+if (! HMAC_KEY || ! API_KEY) {
+  console.error('Error: You must set FXA_AMPLITUDE_HMAC_KEY and FXA_AMPLITUDE_API_KEY environment variables')
+  process.exit(1)
+}
+
+processData()
+  .then(count => {
+    console.log(`Sent ${count} events!`)
+    process.exit(0)
+  })
+  .catch(error => {
+    console.error(error.stack)
+    process.exit(1)
+  })
+
+function processData () {
+  const timeParts = TIMESTAMP.exec(process.argv[2])
+
+  if (timeParts && timeParts.length === 6) {
+    if (! AWS_ACCESS_KEY || ! AWS_SECRET_KEY) {
+      console.error('Error: You must set AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables')
+      process.exit(1)
+    }
+
+    return processDataFromS3(timeParts.slice(1))
+      .then(counts => counts.reduce((sum, count) => sum + count, 0))
+  }
+
+  return processStream(fs.createReadStream(process.argv[2]))
+}
+
+function processStream (stream) {
+  let eventCount = 0, batch = [], error
+
+  return new Promise((resolve, reject) => {
+    stream
+      .pipe(new AutoDetectDecoderStream())
+      .pipe(csv())
+      .on('data', row => {
+        const event = createEvent(row)
+        if (! event) {
+          return
+        }
+
+        batch.push(event)
+
+        if (batch.length < MAX_EVENTS_PER_BATCH) {
+          return
+        }
+
+        const localBatch = batch.slice()
+        batch = []
+        send(localBatch).catch(() => {})
+      })
+      .on('end', () => {
+        if (error) {
+          reject(error)
+        } else if (batch.length === 0) {
+          resolve(eventCount)
+        } else {
+          send(batch)
+            .then(() => resolve(eventCount))
+            .catch(reject)
+        }
+      })
+  })
+
+  function send (localBatch) {
+    if (error) {
+      return Promise.reject(error)
+    }
+
+    return sendBatch(localBatch)
+      .then(() => eventCount += localBatch.length)
+      .catch(e => {
+        error = e
+        throw error
+      })
+  }
+}
+
+function createEvent (row) {
+  const eventType = getEventType(row)
+  if (! eventType) {
+    return
+  }
+
+  const time = getTime(row)
+  if (! time || time < 0) {
+    return
+  }
+
+  const user_id = row.FXA_ID
+  const email_id = row.EmailName
+
+  return {
+    event_type: `mktg - ${eventType}`,
+    time,
+    user_id,
+    session_id: -1,
+    insert_id: getInsertId(user_id, eventType, time, email_id),
+    event_properties: getEventProperties(row)
+  }
+}
+
+function getEventType (row) {
+  const eventParts = EVENT.exec(row.Event)
+  if (eventParts && eventParts.length === 2) {
+    return eventParts[1]
+  }
+}
+
+function getTime (row) {
+  const time = Date.parse(row.EventDate)
+  if (! isNaN(time)) {
+    return Math.round(time / 1000)
+  }
+}
+
+function getInsertId (...properties) {
+  const hmac = crypto.createHmac('sha256', HMAC_KEY)
+
+  properties.forEach(property => hmac.update(`${property}`))
+
+  return hmac.digest('hex')
+}
+
+// Event properties are parsed from the EmailName column, which has
+// a somewhat arcane format defined here:
+//
+// https://docs.google.com/spreadsheets/d/11rvrVdF4fj5GaKOvlnLcNjnWB7U7yKV_MHmlBwRE-WA/edit#gid=1626564614
+//
+// You can see how this regex breaks it down, using the examples from
+// that spreadsheet, here:
+//
+// https://regex101.com/r/Ih5SL4/3/
+const EVENT_PROPERTIES = /^([A-Za-z]+)_([A-Z]+)_[A-Z]*_[0-9]{4}_[A-Z]+_([A-Z]+|DESK[_ ][A-Z]+)_(.+?)_(ALL|[A-Z]{2})_([A-Z]{2,4})_([A-Z-]+)(?:_[A-Za-z0-9]*)?$/
+
+function getEventProperties (row) {
+  const properties = EVENT_PROPERTIES.exec(row.EmailName)
+  if (properties && properties.length === 8) {
+    return {
+      email_sender: properties[1],
+      email_region: properties[2],
+      email_format: properties[3],
+      email_id: properties[4],
+      email_country: properties[5],
+      email_language: properties[6],
+      email_channel: properties[7]
+    }
+  }
+}
+
+function sendBatch (batch) {
+  return request('https://api.amplitude.com/httpapi', {
+    method: 'POST',
+    formData: {
+      api_key: API_KEY,
+      event: JSON.stringify(batch)
+    }
+  })
+}
+
+function processDataFromS3 (timeParts) {
+  const client = s3.createClient({
+    s3Options: {
+      accessKeyId: AWS_ACCESS_KEY,
+      secretKey: AWS_SECRET_KEY,
+    }
+  })
+
+  return getKeysFromS3(client, timeParts)
+    .then(keys => Promise.all(keys.map(key => processStream(client.downloadStream({
+      Bucket: AWS_S3_BUCKET,
+      Key: key
+    })))))
+}
+
+function getKeysFromS3 (client, timeParts) {
+  return new Promise((resolve, reject) => {
+    const keys = []
+    const emitter = client.listObjects({
+      s3Params: {
+        Bucket: AWS_S3_BUCKET,
+        // TODO: change this to match the file names in S3
+        Marker: `${AWS_S3_PREFIX}/${timeParts.join('-')}`,
+        Prefix: AWS_S3_PREFIX
+      }
+    })
+    emitter.on('error', error => reject(error))
+    emitter.on('data', data => data.Contents.forEach(datum => keys.push(datum.key)))
+    emitter.on('end', () => resolve(keys))
+  })
+}
+

--- a/marketing.js
+++ b/marketing.js
@@ -145,9 +145,9 @@ function getEventType (row) {
 }
 
 function getTime (row) {
-  let time = moment(row.EventDate, 'MMM D YYYY  H:mmA')
+  const time = moment(row.EventDate, 'MMM D YYYY  H:mmA')
   if (time.isValid()) {
-    return time.unix();
+    return time.unix()
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -28,12 +28,12 @@
       }
     },
     "ajv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
-      "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
@@ -47,7 +47,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -63,9 +63,9 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
@@ -106,6 +106,24 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "autodetect-decoder-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/autodetect-decoder-stream/-/autodetect-decoder-stream-1.0.0.tgz",
+      "integrity": "sha1-U5jPfKcE/iuxopfuBU/OplitJg0=",
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.6.0"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.0.31",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
+      "integrity": "sha1-5yzx/caQFb2f0r3z07iMFlB9Jo4=",
+      "requires": {
+        "xml2js": "0.2.6",
+        "xmlbuilder": "0.4.2"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -177,13 +195,13 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
@@ -211,32 +229,32 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "supports-color": "5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -250,7 +268,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -276,7 +294,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -289,9 +307,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -303,13 +321,13 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.5",
         "typedarray": "0.0.6"
       }
     },
@@ -324,7 +342,7 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -342,9 +360,21 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         }
+      }
+    },
+    "csv-parser": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-1.12.0.tgz",
+      "integrity": "sha512-kdJUgym8a+vWzAwkqspFEXnDwD3QRWoNsak6H+CrhrrD3hcFsqeb3GiMUUZs5DY6zgMAsvgskfVia1DjxItW1Q==",
+      "requires": {
+        "generate-function": "1.1.0",
+        "generate-object-property": "1.2.0",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "ndjson": "1.5.0"
       }
     },
     "dashdash": {
@@ -358,7 +388,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -382,7 +412,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "rimraf": "2.2.8"
       }
     },
     "delayed-stream": {
@@ -391,9 +421,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "doctrine": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -415,35 +445,35 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.12.1.tgz",
-      "integrity": "sha512-28hOYej+NZ/R5H1yMvyKa1+bPlu+fnsIAQffK6hxXgvmXnImos2bA5XfCn5dYv2k2mrKj+/U/Z4L5ICWxC7TQw==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
+      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "concat-stream": "1.6.0",
+        "chalk": "2.3.2",
+        "concat-stream": "1.6.1",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.2",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.0.1",
+        "globals": "11.3.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -452,7 +482,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -471,24 +501,30 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
+        "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
     "espree": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.5.3",
         "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esquery": {
@@ -501,13 +537,12 @@
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -530,7 +565,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -544,9 +579,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -601,6 +636,14 @@
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
       }
     },
     "forever-agent": {
@@ -609,13 +652,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "fs.realpath": {
@@ -630,6 +673,19 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-1.1.0.tgz",
+      "integrity": "sha1-VMIbCAGSsW2Yd3ecW7gWZudyNl8="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -641,7 +697,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -653,9 +709,9 @@
       }
     },
     "globals": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.0.1.tgz",
-      "integrity": "sha1-Eqh7sBDlFUOWrMU14eQ/x1Ow5eg=",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
       "dev": true
     },
     "globby": {
@@ -673,10 +729,12 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+      "requires": {
+        "natives": "1.1.1"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -688,7 +746,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.2",
         "har-schema": "2.0.0"
       }
     },
@@ -702,9 +760,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "hawk": {
@@ -714,7 +772,7 @@
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "sntp": "2.1.0"
       }
     },
@@ -724,9 +782,9 @@
       "integrity": "sha1-W2KB2R3YjHnfpRtC8I2sTML5rpI="
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -735,19 +793,18 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.1"
       }
     },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -769,22 +826,21 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
         "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -830,14 +886,16 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -847,8 +905,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -868,12 +925,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "esprima": "4.0.0"
       }
     },
@@ -882,6 +939,11 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
+    },
+    "jschardet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -926,14 +988,14 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -946,31 +1008,31 @@
       "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1005,16 +1067,32 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
+    },
     "natives": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA=="
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "5.0.1",
+        "minimist": "1.2.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
+      }
     },
     "node-parquet": {
       "version": "0.2.6",
@@ -1023,15 +1101,8 @@
       "requires": {
         "hexdump-nodejs": "0.1.0",
         "minimist": "1.2.0",
-        "nan": "2.8.0",
+        "nan": "2.9.2",
         "varint": "5.0.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-        }
       }
     },
     "oauth-sign": {
@@ -1060,7 +1131,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -1129,7 +1200,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -1139,10 +1210,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -1167,47 +1237,46 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
       }
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
+        "form-data": "2.3.2",
         "har-validator": "5.0.3",
         "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "request-promise": {
@@ -1218,7 +1287,7 @@
         "bluebird": "3.5.1",
         "request-promise-core": "1.1.1",
         "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
+        "tough-cookie": "2.3.4"
       }
     },
     "request-promise-core": {
@@ -1226,7 +1295,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "require-uncached": {
@@ -1256,13 +1325,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
     },
     "run-async": {
       "version": "2.3.0",
@@ -1302,48 +1367,6 @@
         "pend": "1.2.0",
         "rimraf": "2.2.8",
         "streamsink": "1.2.0"
-      },
-      "dependencies": {
-        "aws-sdk": {
-          "version": "2.0.31",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
-          "integrity": "sha1-5yzx/caQFb2f0r3z07iMFlB9Jo4=",
-          "requires": {
-            "xml2js": "0.2.6",
-            "xmlbuilder": "0.4.2"
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "requires": {
-            "natives": "1.1.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        },
-        "sax": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
-          "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw="
-        },
-        "xml2js": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
-          "integrity": "sha1-0gnE5N2h/JxFIUHvQcB39a399sQ=",
-          "requires": {
-            "sax": "0.4.2"
-          }
-        },
-        "xmlbuilder": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
-          "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M="
-        }
       }
     },
     "safe-buffer": {
@@ -1351,10 +1374,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "sax": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+      "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw="
+    },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "shebang-command": {
@@ -1381,7 +1409,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -1392,7 +1420,15 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {
@@ -1402,9 +1438,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -1429,7 +1465,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -1440,7 +1476,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -1482,13 +1517,13 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "chalk": "2.3.2",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       }
@@ -1505,28 +1540,31 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.5",
+        "xtend": "4.0.1"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
       }
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -1560,13 +1598,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "varint": {
       "version": "5.0.0",
@@ -1586,7 +1623,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -1612,6 +1649,24 @@
       "requires": {
         "mkdirp": "0.5.1"
       }
+    },
+    "xml2js": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+      "integrity": "sha1-0gnE5N2h/JxFIUHvQcB39a399sQ=",
+      "requires": {
+        "sax": "0.4.2"
+      }
+    },
+    "xmlbuilder": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+      "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,6 +1055,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1060,6 +1060,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
+    "moment-timezone": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+      "requires": {
+        "moment": "2.22.2"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,14 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -992,6 +1000,23 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "lookup-dns-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lookup-dns-cache/-/lookup-dns-cache-2.0.0.tgz",
+      "integrity": "sha512-O/Kz1J1iCdDXQetbqoDmAgXlfwXfgCV/g40V9fGoQC7X4MXRETYqzv2n1HNgpHvdHewxIbIpkHTk2PRum4LBcA==",
+      "requires": {
+        "async": "2.6.0",
+        "lodash": "4.17.4",
+        "rr": "0.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
+      }
+    },
     "lru-cache": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
@@ -1341,6 +1366,11 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+    },
+    "rr": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rr/-/rr-0.1.0.tgz",
+      "integrity": "sha1-oY7CXslKZ8NfIQuzqF0XkU55zR4="
     },
     "run-async": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "fxa-amplitude-send",
   "version": "0.0.0",
   "dependencies": {
+    "autodetect-decoder-stream": "^1.0.0",
     "bluebird": "^3.5.1",
+    "csv-parser": "^1.12.0",
     "node-parquet": "^0.2.6",
-    "request": "^2.83.0",
+    "request": "^2.85.0",
     "request-promise": "^4.2.2",
     "s3": "^4.4.0"
   },
   "devDependencies": {
-    "eslint": "^4.12.1",
+    "eslint": "^4.18.2",
     "eslint-plugin-fxa": "^1.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bluebird": "^3.5.1",
     "csv-parser": "^1.12.0",
     "moment": "^2.22.2",
+    "moment-timezone": "^0.5.21",
     "node-parquet": "^0.2.6",
     "request": "^2.85.0",
     "request-promise": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "autodetect-decoder-stream": "^1.0.0",
     "bluebird": "^3.5.1",
     "csv-parser": "^1.12.0",
+    "moment": "^2.22.2",
     "node-parquet": "^0.2.6",
     "request": "^2.85.0",
     "request-promise": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "autodetect-decoder-stream": "^1.0.0",
     "bluebird": "^3.5.1",
     "csv-parser": "^1.12.0",
+    "lookup-dns-cache": "^2.0.0",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.21",
     "node-parquet": "^0.2.6",


### PR DESCRIPTION
@rfk, @jbuck, this is a script to process the marketing email event CSV format and send it to Amplitude. There's a fair amount of duplication with the proposed sync script for #36, so we should be able to extract the common stuff as they land.

Should be nothing too surprising hopefully, the only small gotcha was the CSV we received was UTF-16 encoded, so I've added an encoding detection/transform step before piping data to the CSV parser. Happily, unlike the parquet parser, this one operates on a stream so we don't have to download the entire file before processing it.

I'm sticking a `WIP` label on this until we actually have the automated exports dumping to S3 and can verify that part of the code (the S3 bit is untested so far).

Co-authored with @jbuck.