### PR TITLE
feat(debug): add a script to check raw event logs for potential issues

### DIFF
--- a/check-events.js
+++ b/check-events.js
@@ -238,15 +238,13 @@ function displayStat (stat, description) {
     count: stat[key].length,
     percentage: Math.round(stat[key].length / events[key].length * 100)
   }))
-  const categoryCounts = categories
-    .map(item => `${item.category}: ${item.count} / ${item.percentage}%`)
-    .join(', ')
 
   const count = categories.reduce((sum, item) => sum + item.count, 0)
   const eventCount = Object.keys(events).reduce((sum, key) => sum + events[key].length, 0)
   const percentage = Math.round(count / eventCount * 100)
 
-  console.log(`${description}: ${count} / ${percentage}% (${categoryCounts})`)
+  console.log(`${description}: ${count} (${percentage}%)`)
+  categories.forEach(item => console.log(`  ${item.category}: ${item.count} (${item.percentage}%)`))
 }
 
 function displayStatVerbose (stat, description) {
@@ -268,7 +266,7 @@ function displayConflict (property, conflicts) {
   const count = conflicts.length
   const percentage = Math.round(count / events.auth.length * 100)
 
-  console.log(`CONFLICTING ${property}: ${count} / ${percentage}%`)
+  console.log(`CONFLICTING ${property}: ${count} (${percentage}%)`)
   if (VERBOSE) {
     conflicts.forEach(datum => console.log(datum))
   }

--- a/check-events.js
+++ b/check-events.js
@@ -130,7 +130,7 @@ const events = fileNames.reduce((previousEvents, fileName) => {
 
         const device = getDevice(deviceId)
 
-        multiMapSet(device.sessionUsers, sessionId, userId)
+        multiMapSet(device.sessionUsers, sessionId, uid)
 
         devices.set(deviceId, device)
       }

--- a/check-events.js
+++ b/check-events.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const TIME_FORMAT = /(201[78])-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})/
+const CATEGORY_FORMAT = /^logging\.s3\.fxa\.([a-z]+)_server/
+const VERBOSE = false
+
+const args = process.argv
+
+if (args.length !== 4) {
+  usage()
+}
+
+let from = TIME_FORMAT.exec(args[2])
+let until = TIME_FORMAT.exec(args[3])
+
+if (! from || ! until) {
+  usage()
+}
+
+from = from.slice(1)
+until = until.slice(1)
+
+const cwd = process.cwd()
+const fileNames = fs.readdirSync(cwd)
+
+const missingDeviceIds = []
+const missingSessionIds = []
+const futureSessionIds = []
+const futureTimes = []
+const users = new Map()
+
+const events = fileNames.reduce((previousEvents, fileName) => {
+  let time = TIME_FORMAT.exec(fileName)
+  if (! time) {
+    return
+  }
+
+  time = time.slice(1)
+  if (! isInRange(time)) {
+    return
+  }
+
+  let category = CATEGORY_FORMAT.exec(fileName)
+  if (! category) {
+    return
+  }
+
+  category = category[1]
+  if (! previousEvents[category]) {
+    return
+  }
+
+  const target = timestamp(time)
+  const isContentServerEvent = category === 'content'
+
+  const text = fs.readFileSync(path.join(cwd, fileName), { encoding: 'utf8' })
+  const lines = text.split('\n')
+  const data = lines
+    .filter(line => !! line.trim())
+    .map((line, index) => {
+      const event = JSON.parse(line)
+      const datum = {
+        file: fileName,
+        line: index + 1,
+        time: target,
+        event
+      }
+
+      const deviceId = event.device_id
+      if (! deviceId) {
+        missingDeviceIds.push(datum)
+      }
+
+      const sessionId = event.session_id
+      if (! event.session_id) {
+        missingSessionIds.push(datum)
+      }
+
+      if (event.session_id > target) {
+        futureSessionIds.push(datum)
+      }
+
+      if (event.time > target) {
+        futureTimes.push(datum)
+      }
+
+      const uid = event.user_id
+      if (isContentServerEvent) {
+        const user = users.get(uid) || {
+          deviceSessions: new Map(),
+          sessionDevices: new Map()
+        }
+
+        const deviceSessions = user.deviceSessions.get(deviceId) || new Set()
+        deviceSessions.add(sessionId)
+        user.deviceSessions.set(deviceId, deviceSessions)
+
+        const sessionDevices = user.sessionDevices.get(sessionId) || new Set()
+        sessionDevices.add(deviceId)
+        user.sessionDevices.set(sessionId, sessionDevices)
+
+        users.set(uid, user)
+      }
+
+      return datum
+    })
+
+  previousEvents[category] = previousEvents[category].concat(data)
+  return previousEvents
+}, {
+  content: [],
+  auth: []
+})
+
+const contentCount = events.content.length
+const authCount = events.auth.length
+console.log('EVENTS:', contentCount + authCount)
+console.log('CONTENT:', contentCount)
+console.log('AUTH:', authCount)
+
+console.log('MISSING device_id:', missingDeviceIds.length)
+if (VERBOSE) {
+  missingDeviceIds.forEach(datum => console.log(datum))
+}
+
+console.log('MISSING session_id:', missingSessionIds.length)
+if (VERBOSE) {
+  missingSessionIds.forEach(datum => console.log(datum))
+}
+
+console.log('FUTURE session_id:', futureSessionIds.length)
+if (VERBOSE) {
+  futureSessionIds.forEach(datum => console.log(datum))
+}
+
+console.log('FUTURE time:', futureTimes.length)
+if (VERBOSE) {
+  futureTimes.forEach(datum => console.log(datum))
+}
+
+const conflictingDeviceIds = []
+const conflictingSessionIds = []
+
+events.auth.forEach(datum => {
+  const event = datum.event
+  const user = users.get(event.user_id) || {
+    deviceSessions: new Map(),
+    sessionDevices: new Map()
+  }
+
+  const deviceId = event.device_id
+  const sessionId = event.session_id
+
+  const deviceSessions = user.deviceSessions.get(deviceId)
+  if (deviceSessions && ! deviceSessions.has(sessionId)) {
+    conflictingSessionIds.push(datum)
+  }
+
+  const sessionDevices = user.sessionDevices.get(sessionId)
+  if (sessionDevices && ! sessionDevices.has(deviceId)) {
+    conflictingDeviceIds.push(datum)
+  }
+})
+
+console.log('CONFLICTING device_id:', conflictingDeviceIds.length)
+if (VERBOSE) {
+  conflictingDeviceIds.forEach(datum => console.log(datum))
+}
+
+console.log('CONFLICTING session_id:', conflictingSessionIds.length)
+if (VERBOSE) {
+  conflictingSessionIds.forEach(datum => console.log(datum))
+}
+
+function usage () {
+  console.error(`Usage: node ${args[1]} FROM UNTIL`)
+  console.error('FROM and UNTIL are both YYYY-MM-DD-hh-mm')
+  process.exit(1)
+}
+
+function isInRange (time) {
+  return satisfiesOrEquals(time, from, (lhs, rhs) => lhs - rhs) &&
+    satisfiesOrEquals(time, until, (lhs, rhs) => rhs - lhs)
+}
+
+function satisfiesOrEquals (subject, object, diff) {
+  let result = true
+
+  object.some((item, index) => {
+    const d = diff(+subject[index], +item)
+    if (d > 0) {
+      return true
+    }
+
+    if (d < 0) {
+      result = false
+      return true
+    }
+
+    return false
+  })
+
+  return result
+}
+
+function timestamp (time) {
+  return Date.parse(`${time[0]}-${time[1]}-${time[2]}T${time[3]}:${time[4]}:59.999`)
+}
+

--- a/check-events.js
+++ b/check-events.js
@@ -85,14 +85,12 @@ const events = fileNames.reduce((previousEvents, fileName) => {
       const sessionId = event.session_id
 
       if (! deviceId) {
-        missingDeviceIds.push(datum)
-
         if (! sessionId) {
           missingDeviceAndSessionIds.push(datum)
+        } else {
+          missingDeviceIds.push(datum)
         }
-      }
-
-      if (! sessionId) {
+      } else if (! sessionId) {
         missingSessionIds.push(datum)
       }
 

--- a/check-events.js
+++ b/check-events.js
@@ -233,11 +233,20 @@ function multiMapSet (map, key, value) {
 }
 
 function displayStat (stat, description) {
-  const categories = Object.keys(stat).map(key => ({ category: key, count: stat[key].length }))
-  const count = categories.reduce((sum, item) => sum + item.count, 0)
-  const categoryCounts = categories.map(item => `${item.category}: ${item.count}`).join(', ')
+  const categories = Object.keys(stat).map(key => ({
+    category: key,
+    count: stat[key].length,
+    percentage: Math.round(stat[key].length / events[key].length * 100)
+  }))
+  const categoryCounts = categories
+    .map(item => `${item.category}: ${item.count} / ${item.percentage}%`)
+    .join(', ')
 
-  console.log(`${description}: ${count} (${categoryCounts})`)
+  const count = categories.reduce((sum, item) => sum + item.count, 0)
+  const eventCount = Object.keys(events).reduce((sum, key) => sum + events[key].length, 0)
+  const percentage = Math.round(count / eventCount * 100)
+
+  console.log(`${description}: ${count} / ${percentage}% (${categoryCounts})`)
 }
 
 function displayStatVerbose (stat, description) {
@@ -256,7 +265,10 @@ function optionallySetConflict (conflicts, datum, map, key, value) {
 }
 
 function displayConflict (property, conflicts) {
-  console.log(`CONFLICTING ${property}: ${conflicts.length}`)
+  const count = conflicts.length
+  const percentage = Math.round(count / events.auth.length * 100)
+
+  console.log(`CONFLICTING ${property}: ${count} / ${percentage}%`)
   if (VERBOSE) {
     conflicts.forEach(datum => console.log(datum))
   }

--- a/check-events.js
+++ b/check-events.js
@@ -28,26 +28,12 @@ until = until.slice(1)
 const cwd = process.cwd()
 const fileNames = fs.readdirSync(cwd)
 
-const missingDeviceIds = {
-  content: [],
-  auth: []
-}
-const missingSessionIds = {
-  content: [],
-  auth: []
-}
-const missingDeviceAndSessionIds = {
-  content: [],
-  auth: []
-}
-const futureSessionIds = {
-  content: [],
-  auth: []
-}
-const futureTimes = {
-  content: [],
-  auth: []
-}
+const missingDeviceIds = createStat()
+const missingSessionIds = createStat()
+const missingDeviceAndSessionIds = createStat()
+const futureSessionIds = createStat()
+const futureTimes = createStat()
+
 const users = new Map()
 
 const events = fileNames.reduce((previousEvents, fileName) => {
@@ -139,20 +125,14 @@ const events = fileNames.reduce((previousEvents, fileName) => {
 
   previousEvents[category] = previousEvents[category].concat(data)
   return previousEvents
-}, {
-  content: [],
-  auth: []
-})
+}, createStat())
 
-const contentCount = events.content.length
-const authCount = events.auth.length
-console.log(`EVENTS: ${contentCount + authCount} (content: ${contentCount}, auth: ${authCount})`)
-
-displayStat(missingDeviceIds, 'MISSING device_id')
-displayStat(missingSessionIds, 'MISSING session_id')
-displayStat(missingDeviceAndSessionIds, 'MISSING device_id AND session_id')
-displayStat(futureSessionIds, 'FUTURE session_id')
-displayStat(futureTimes, 'FUTURE time')
+displayStat(events, 'EVENTS')
+displayStatVerbose(missingDeviceIds, 'MISSING device_id')
+displayStatVerbose(missingSessionIds, 'MISSING session_id')
+displayStatVerbose(missingDeviceAndSessionIds, 'MISSING device_id AND session_id')
+displayStatVerbose(futureSessionIds, 'FUTURE session_id')
+displayStatVerbose(futureTimes, 'FUTURE time')
 
 const conflictingDeviceIds = []
 const conflictingSessionIds = []
@@ -219,6 +199,13 @@ function satisfiesOrEquals (subject, object, diff) {
   return result
 }
 
+function createStat () {
+   return {
+    content: [],
+    auth: []
+  }
+}
+
 function timestamp (time) {
   return Date.parse(`${time[0]}-${time[1]}-${time[2]}T${time[3]}:${time[4]}:59.999`)
 }
@@ -229,6 +216,10 @@ function displayStat (stat, description) {
   const categoryCounts = categories.map(item => `${item.category}: ${item.count}`).join(', ')
 
   console.log(`${description}: ${count} (${categoryCounts})`)
+}
+
+function displayStatVerbose (stat, description) {
+  displayStat(stat, description)
 
   if (VERBOSE) {
     Object.keys(stat).forEach(key => stat[key].forEach(datum => console.log(datum)))

--- a/check-events.js
+++ b/check-events.js
@@ -30,6 +30,7 @@ const fileNames = fs.readdirSync(cwd)
 
 const missingUserAndDeviceAndSessionIds = createStat()
 const missingUserAndDeviceIds = createStat()
+const missingUserAndSessionIds = createStat()
 const missingDeviceAndSessionIds = createStat()
 const missingUserIds = createStat()
 const missingDeviceIds = createStat()
@@ -96,6 +97,8 @@ const events = fileNames.reduce((previousEvents, fileName) => {
           } else {
             missingUserAndDeviceIds[category].push(datum)
           }
+        } else if (! sessionId) {
+          missingUserAndSessionIds[category].push(datum)
         } else {
           missingUserIds[category].push(datum)
         }
@@ -142,6 +145,7 @@ const events = fileNames.reduce((previousEvents, fileName) => {
 displayStat(events, 'EVENTS')
 displayStatVerbose(missingUserAndDeviceAndSessionIds, 'MISSING user_id AND device_id AND session_id')
 displayStatVerbose(missingUserAndDeviceIds, 'MISSING user_id AND device_id')
+displayStatVerbose(missingUserAndSessionIds, 'MISSING user_id AND session_id')
 displayStatVerbose(missingDeviceAndSessionIds, 'MISSING device_id AND session_id')
 displayStatVerbose(missingUserIds, 'MISSING user_id')
 displayStatVerbose(missingDeviceIds, 'MISSING device_id')
@@ -149,9 +153,9 @@ displayStatVerbose(missingSessionIds, 'MISSING session_id')
 displayStatVerbose(futureSessionIds, 'FUTURE session_id')
 displayStatVerbose(futureTimes, 'FUTURE time')
 
+const conflictingUserIds = []
 const conflictingDeviceIds = []
 const conflictingSessionIds = []
-const conflictingUserIds = []
 
 events.auth.forEach(datum => {
   const event = datum.event


### PR DESCRIPTION
Not sure whether we want to merge this or not, it depends whether it helps us debug #27.

Anyway, the idea is that we can run this against raw logs from a time when the problem exists and a time when the problem doesn't exist, and it will help us zero in on specific events that have issues. There's no logic for downloading from S3 or unzipping the data, so those steps are pre-requisites to running the script.

Once you have the logs in a directory somewhere, `cd` into it and run this script. It takes two arguments, a `from` time and an `until` time, both in the format `YYYY-MM-DD-hh-mm`. The script will process all log files for that time range in the current working directory, reporting:

* The total count of events processed across all files
* The count of those that were content server events
* The count of those that were auth server events
* The count that were missing a `device_id` property
* The count that were missing a `session_id` property
* The count that had a `session_id` property greater than the timestamp of the log file
* The count that had a `time` property greater than the timestamp of the log file
* The count of auth server events where the `device_id` for a particular user and session doesn't match the value from the content server events
* The count of auth server events where the `session_id` for a particular user and device doesn't match the value from the content server events

Those are based on the hypotheses put forward in #27, we can add further checks as we think of them.

There is also a `VERBOSE` mode that can be triggered by flipping the switch on line 10 (we can change that to a command line switch if this is going to stick around). Running in that mode will output all of the flagged events, the file they came from and their line number in the file.

My thinking regarding usage is to run in non-verbose mode across a wide range of data and gradually try to zero in on a smaller window that shows a problem. Then, when it's been pinned down to just a few log files, we can flip on `VERBOSE` mode and take a look at the specific events.

No idea if this will help us get to the bottom of things, me and @jbuck have a debug session to try it out shortly. Hopefully it works!
