### PR TITLE
Changes to make reading from many files more easily

### DIFF
--- a/check-events.js
+++ b/check-events.js
@@ -9,24 +9,12 @@ const TIME_FORMAT = /(201[78])-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})/
 const CATEGORY_FORMAT = /^logging\.s3\.fxa\.([a-z]+)_server/
 const VERBOSE = false
 
-const args = process.argv
+const args = process.argv.slice(2);
+const fileNames = args.map((directory) => { return fs.readdirSync(directory); })
+  .reduce((a, b) => return a.concat(b), [])
 
-if (args.length !== 4) {
-  usage()
-}
-
-let from = TIME_FORMAT.exec(args[2])
-let until = TIME_FORMAT.exec(args[3])
-
-if (! from || ! until) {
-  usage()
-}
-
-from = from.slice(1)
-until = until.slice(1)
-
-const cwd = process.cwd()
-const fileNames = fs.readdirSync(cwd)
+console.log(args);
+console.log(fileNames);
 
 const missingUserAndDeviceAndSessionIds = createStat()
 const missingUserAndDeviceIds = createStat()

--- a/check-events.js
+++ b/check-events.js
@@ -7,7 +7,7 @@ const path = require('path')
 const zlib = require('zlib')
 
 const TIME_FORMAT = /(201[78])-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})/
-const CATEGORY_FORMAT = /^logging\.s3\.fxa\.([a-z]+)_server/
+const CATEGORY_FORMAT = /logging\.s3\.fxa\.([a-z]+)_server/
 const VERBOSE = false
 
 const args = process.argv.slice(2);
@@ -53,9 +53,9 @@ const events = fileNames.reduce((previousEvents, fileName) => {
   const fileBuffer = fs.readFileSync(fileName);
   let text;
   if (fileBuffer[0] == 0x1F && fileBuffer[1] == 0x8B && fileBuffer[2] == 0x8) {
-    text = zlib.gunzipSync(fileBuffer)
+    text = zlib.gunzipSync(fileBuffer).toString('utf8')
   } else {
-    text = fileBuffer.toString('utf8');
+    text = fileBuffer.toString('utf8')
   }
 
   const lines = text.split('\n')

--- a/check-events.js
+++ b/check-events.js
@@ -4,17 +4,17 @@
 
 const fs = require('fs')
 const path = require('path')
+const zlib = require('zlib')
 
 const TIME_FORMAT = /(201[78])-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})/
 const CATEGORY_FORMAT = /^logging\.s3\.fxa\.([a-z]+)_server/
 const VERBOSE = false
 
 const args = process.argv.slice(2);
-const fileNames = args.map((directory) => { return fs.readdirSync(directory) })
+const fileNames = args.map((directory) => {
+    return fs.readdirSync(directory).map((file) => { return path.join(directory, file) })
+  })
   .reduce((a, b) => { return a.concat(b) }, [])
-
-console.log(args);
-console.log(fileNames);
 
 const missingUserAndDeviceAndSessionIds = createStat()
 const missingUserAndDeviceIds = createStat()
@@ -36,9 +36,6 @@ const events = fileNames.reduce((previousEvents, fileName) => {
   }
 
   time = time.slice(1)
-  if (! isInRange(time)) {
-    return
-  }
 
   let category = CATEGORY_FORMAT.exec(fileName)
   if (! category) {
@@ -53,7 +50,14 @@ const events = fileNames.reduce((previousEvents, fileName) => {
   const target = timestamp(time)
   const isContentServerEvent = category === 'content'
 
-  const text = fs.readFileSync(path.join(cwd, fileName), { encoding: 'utf8' })
+  const fileBuffer = fs.readFileSync(fileName);
+  let text;
+  if (fileBuffer[0] == 0x1F && fileBuffer[1] == 0x8B && fileBuffer[2] == 0x8) {
+    text = zlib.gunzipSync(fileBuffer)
+  } else {
+    text = fileBuffer.toString('utf8');
+  }
+
   const lines = text.split('\n')
   const data = lines
     .filter(line => !! line.trim() && line.indexOf("amplitudeEvent") !== -1)
@@ -167,31 +171,6 @@ function usage () {
   console.error(`Usage: node ${args[1]} FROM UNTIL`)
   console.error('FROM and UNTIL are both YYYY-MM-DD-hh-mm')
   process.exit(1)
-}
-
-function isInRange (time) {
-  return satisfiesOrEquals(time, from, (lhs, rhs) => lhs - rhs) &&
-    satisfiesOrEquals(time, until, (lhs, rhs) => rhs - lhs)
-}
-
-function satisfiesOrEquals (subject, object, diff) {
-  let result = true
-
-  object.some((item, index) => {
-    const d = diff(+subject[index], +item)
-    if (d > 0) {
-      return true
-    }
-
-    if (d < 0) {
-      result = false
-      return true
-    }
-
-    return false
-  })
-
-  return result
 }
 
 function createStat () {

--- a/check-events.js
+++ b/check-events.js
@@ -10,8 +10,8 @@ const CATEGORY_FORMAT = /^logging\.s3\.fxa\.([a-z]+)_server/
 const VERBOSE = false
 
 const args = process.argv.slice(2);
-const fileNames = args.map((directory) => { return fs.readdirSync(directory); })
-  .reduce((a, b) => return a.concat(b), [])
+const fileNames = args.map((directory) => { return fs.readdirSync(directory) })
+  .reduce((a, b) => { return a.concat(b) }, [])
 
 console.log(args);
 console.log(fileNames);

--- a/check-events.js
+++ b/check-events.js
@@ -122,7 +122,7 @@ const events = fileNames.reduce((previousEvents, fileName) => {
 
         const device = getDevice(deviceId)
 
-        multiMapSet(device.sessionUsers, sessionId, userId)
+        multiMapSet(device.sessionUsers, sessionId, uid)
 
         devices.set(deviceId, device)
       }


### PR DESCRIPTION
@philbooth I made some changes to the script here to make it easier to run this script on a larger corpus of data. It does have some problems still when running on an entire day's worth of data:

```
$ node ~/bin/check-events.js fxa-content/2018/01/17/* fxa-auth/2018/01/17/*

<--- Last few GCs --->

[540:0x25e94c0]   273831 ms: Mark-sweep 1355.1 (1418.9) -> 1355.1 (1419.4) MB, 1295.8 / 0.0 ms  allocation failure GC in old space requested
[540:0x25e94c0]   275133 ms: Mark-sweep 1355.1 (1419.4) -> 1355.1 (1387.4) MB, 1302.3 / 0.0 ms  last resort GC in old space requested
[540:0x25e94c0]   276424 ms: Mark-sweep 1355.1 (1387.4) -> 1355.1 (1387.4) MB, 1291.1 / 0.0 ms  last resort GC in old space requested


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x330b38525501 <JSObject>
    1: stringSlice(aka stringSlice) [buffer.js:590] [bytecode=0x3c418ef68c71 offset=94](this=0x1eab3ce022d1 <undefined>,buf=0x30aa42202251 <Uint8Array map = 0x34beddb45331>,encoding=0x330b38534ea9 <String[4]: utf8>,start=0,end=20246089)
    2: toString [buffer.js:664] [bytecode=0x3c418ef688b9 offset=148](this=0x30aa42202251 <Uint8Array map = 0x34beddb45331>,encoding=0x330b38534ea9 <String[4]: ut...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [node]
 2: 0x11f155c [node]
 3: v8::Utils::ReportOOMFailure(char const*, bool) [node]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [node]
 5: v8::internal::Factory::NewRawTwoByteString(int, v8::internal::PretenureFlag) [node]
 6: v8::internal::Factory::NewStringFromUtf8(v8::internal::Vector<char const>, v8::internal::PretenureFlag) [node]
 7: v8::String::NewFromUtf8(v8::Isolate*, char const*, v8::NewStringType, int) [node]
 8: node::StringBytes::Encode(v8::Isolate*, char const*, unsigned long, node::encoding, v8::Local<v8::Value>*) [node]
 9: 0x120b392 [node]
10: v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) [node]
11: 0xb7e37c [node]
12: v8::internal::Builtin_HandleApiCall(int, v8::internal::Object**, v8::internal::Isolate*) [node]
13: 0x3c3eed842fd
Aborted

```

But it works pretty well when only using an hours worth of data. I'm not sure removing the time changes is the right path, I just did it to have it work.