### PR TITLE
feat(fxa): map content server flow data to amplitude

### DIFF
--- a/flow-to-amplitude.js
+++ b/flow-to-amplitude.js
@@ -1,0 +1,290 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const csv = require('csv-parser')
+const fs = require('fs')
+const s3 = require('s3')
+
+const DATE_FORMAT = /^20[1-9][0-9]-[01][0-9]-[0-3][1-9]$/
+const AWS_ACCESS_KEY = process.env.FXA_AWS_ACCESS_KEY
+const AWS_SECRET_KEY = process.env.FXA_AWS_SECRET_KEY
+const AWS_S3_BUCKET = 'net-mozaws-prod-us-west-2-pipeline-analysis'
+const AWS_S3_PREFIX = 'fxa-flow/data/flow-'
+const AWS_S3_SUFFIX = '.csv'
+
+const SERVICES = {
+  // TODO: populate this if we want the service property to be correct
+}
+
+const GROUPS = {
+  connectDevice: 'fxa_connect_device',
+  email: 'fxa_email',
+  emailFirst: 'fxa_email_first',
+  login: 'fxa_login',
+  registration: 'fxa_reg',
+  settings: 'fxa_pref',
+  sms: 'fxa_sms'
+}
+
+const ENGAGE_SUBMIT_EVENT_GROUPS = {
+  'connect-another-device': GROUPS.connectDevice,
+  'enter-email': GROUPS.emailFirst,
+  'force-auth': GROUPS.login,
+  install_from: GROUPS.connectDevice,
+  signin_from: GROUPS.connectDevice,
+  signin: GROUPS.login,
+  signup: GROUPS.registration,
+  sms: GROUPS.connectDevice
+}
+
+const VIEW_EVENT_GROUPS = {
+  'connect-another-device': GROUPS.connectDevice,
+  'enter-email': GROUPS.emailFirst,
+  'force-auth': GROUPS.login,
+  signin: GROUPS.login,
+  signup: GROUPS.registration,
+  sms: GROUPS.connectDevice
+}
+
+const CONNECT_DEVICE_FLOWS = {
+  'connect-another-device': 'cad',
+  install_from: 'store_buttons',
+  signin_from: 'signin',
+  sms: 'sms'
+}
+
+const EVENTS = {
+  'flow.reset-password.submit': {
+    group: GROUPS.login,
+    event: 'forgot_submit'
+  }
+}
+
+const FUZZY_EVENTS = new Map([
+  [ /^flow\.([\w-]+)\.engage$/, {
+    isDynamicGroup: true,
+    group: eventCategory => ENGAGE_SUBMIT_EVENT_GROUPS[eventCategory],
+    event: 'engage'
+  } ],
+  [ /^flow\.[\w-]+\.forgot-password$/, {
+    group: GROUPS.login,
+    event: 'forgot_pwd'
+  } ],
+  [ /^flow\.[\w-]+\.have-account$/, {
+    group: GROUPS.registration,
+    event: 'have_account'
+  } ],
+  [ /^flow\.((?:install|signin)_from)\.\w+$/, {
+    group: GROUPS.connectDevice,
+    event: 'engage'
+  } ],
+  [ /^flow\.([\w-]+)\.submit$/, {
+    isDynamicGroup: true,
+    group: eventCategory => ENGAGE_SUBMIT_EVENT_GROUPS[eventCategory],
+    event: 'submit'
+  } ],
+  [ /^flow\.([\w-]+)\.view$/, {
+    isDynamicGroup: true,
+    group: eventCategory => VIEW_EVENT_GROUPS[eventCategory],
+    event: 'view'
+  } ]
+])
+
+const EVENT_PROPERTIES = {
+  [GROUPS.connectDevice]: mapConnectDeviceFlow,
+  [GROUPS.emailFirst]: mapService,
+  [GROUPS.login]: mapService,
+  [GROUPS.registration]: mapService
+}
+
+const USER_PROPERTIES = {
+  [GROUPS.connectDevice]: mapFlowId,
+  [GROUPS.emailFirst]: mixProperties(mapFlowId, mapUtmProperties),
+  [GROUPS.login]: mixProperties(mapFlowId, mapUtmProperties),
+  [GROUPS.registration]: mixProperties(mapFlowId, mapUtmProperties)
+}
+
+if (process.argv.length !== 3) {
+  console.error(`Usage: ${process.argv[1]} {YYYY-MM-DD | LOCAL PATH}`)
+  process.exit(1)
+}
+
+Promise.resolve()
+  .then(processData)
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error.stack)
+    process.exit(1)
+  })
+
+function processData () {
+  return new Promise(resolve => {
+    createStream()
+      .pipe(csv({
+        headers: [
+          'timestamp', 'type', 'flow_id', 'flow_time', 'ua_browser',
+          'ua_version', 'ua_os', 'context', 'entrypoint', 'migration',
+          'service', 'utm_campaign', 'utm_content', 'utm_medium',
+          'utm_source', 'utm_term', 'locale', 'uid'
+        ]
+      }))
+      .on('data', row => {
+        const event = transformEvent(row)
+        if (event) {
+          console.log(JSON.stringify(event))
+        }
+      })
+      .on('end', resolve)
+  })
+}
+
+function createStream () {
+  const arg = process.argv[2]
+
+  if (DATE_FORMAT.test(arg)) {
+    if (! AWS_ACCESS_KEY || ! AWS_SECRET_KEY) {
+      throw new Error('You must set AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables')
+    }
+
+    return s3
+      .createClient({
+        s3Options: {
+          accessKeyId: AWS_ACCESS_KEY,
+          secretKey: AWS_SECRET_KEY
+        }
+      })
+      .downloadStream({
+        Bucket: AWS_S3_BUCKET,
+        Key: `${AWS_S3_PREFIX}${arg}${AWS_S3_SUFFIX}`
+      })
+  }
+
+  return fs.createReadStream(arg)
+}
+
+function transformEvent (event) {
+  if (! event) {
+    return
+  }
+
+  const eventType = event.type
+  let mapping = EVENTS[eventType]
+  let eventCategory
+
+  if (! mapping) {
+    for (const [ key, value ] of FUZZY_EVENTS.entries()) {
+      const match = key.exec(eventType)
+      if (match) {
+        mapping = value
+        if (match.length === 2) {
+          eventCategory = match[1]
+        }
+        break
+      }
+    }
+  }
+
+  if (mapping) {
+    let group = mapping.group
+    if (mapping.isDynamicGroup) {
+      group = group(eventCategory)
+      if (! group) {
+        return
+      }
+    }
+
+    return Object.assign({
+      op: 'amplitudeEvent',
+      time: event.time,
+      user_id: event.uid,
+      event_type: `${group} - ${mapping.event}`,
+      session_id: event.timestamp - event.flow_time,
+      event_properties: mapEventProperties(group, mapping.event, eventCategory, event),
+      user_properties: mapUserProperties(group, eventCategory, event),
+      language: event.locale
+    }, mapOs(event))
+  }
+}
+
+function mixProperties (...mappers) {
+  return (event, eventCategory, data) =>
+    Object.assign({}, ...mappers.map(m => m(event, eventCategory, data)))
+}
+
+function mapEventProperties (group, event, eventCategory, data) {
+  return EVENT_PROPERTIES[group](event, eventCategory, data)
+}
+
+function mapUserProperties (group, eventCategory, data) {
+  return Object.assign(
+    {},
+    mapBrowser(data),
+    mapEntrypoint(data),
+    USER_PROPERTIES[group](eventCategory, data)
+  )
+}
+
+function mapOs (data) {
+  const { ua_os } = data
+  if (ua_os) {
+    return { os_name: ua_os }
+  }
+}
+
+function mapBrowser (data) {
+  const { ua_browser, ua_version } = data
+  if (ua_browser) {
+    return { ua_browser, ua_version }
+  }
+}
+
+function mapEntrypoint (data) {
+  const { entrypoint } = data
+  if (entrypoint) {
+    return { entrypoint }
+  }
+}
+
+function mapConnectDeviceFlow (event, eventCategory) {
+  const connect_device_flow = CONNECT_DEVICE_FLOWS[eventCategory]
+  if (connect_device_flow) {
+    return { connect_device_flow }
+  }
+}
+
+function mapService (event, eventCategory, data) {
+  const { service } = data.service
+  if (service) {
+    let serviceName, clientId
+
+    if (service === 'sync') {
+      serviceName = service
+    } else {
+      serviceName = SERVICES[service] || 'undefined_oauth'
+      clientId = service
+    }
+
+    return { service: serviceName, oauth_client_id: clientId }
+  }
+}
+
+function mapFlowId (eventCategory, data) {
+  const { flow_id } = data
+  if (flow_id) {
+    return { flow_id }
+  }
+}
+
+function mapUtmProperties (eventCategory, data) {
+  return {
+    utm_campaign: data.utm_campaign,
+    utm_content: data.utm_content,
+    utm_medium: data.utm_medium,
+    utm_source: data.utm_source,
+    utm_term: data.utm_term
+  }
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
-      "dev": true
-    },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
@@ -47,7 +41,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -250,7 +244,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -276,7 +270,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -347,6 +341,18 @@
         }
       }
     },
+    "csv-parser": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-1.12.0.tgz",
+      "integrity": "sha1-FFP3YneU8T91es5CVv7uItN7yRs=",
+      "requires": {
+        "generate-function": "1.1.0",
+        "generate-object-property": "1.2.0",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "ndjson": "1.5.0"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -358,7 +364,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -390,15 +396,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "doctrine": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -415,9 +412,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.12.1.tgz",
-      "integrity": "sha512-28hOYej+NZ/R5H1yMvyKa1+bPlu+fnsIAQffK6hxXgvmXnImos2bA5XfCn5dYv2k2mrKj+/U/Z4L5ICWxC7TQw==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz",
+      "integrity": "sha1-npAO+1UGgSrDdFVwNO9vXDZC/Ew=",
       "dev": true,
       "requires": {
         "ajv": "5.5.0",
@@ -426,11 +423,11 @@
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.2",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
@@ -451,12 +448,40 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
+        "regexpp": "1.0.1",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
         "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.5.3",
+            "acorn-jsx": "3.0.1"
+          }
+        }
       }
     },
     "eslint-plugin-fxa": {
@@ -475,20 +500,16 @@
         "estraverse": "4.2.0"
       }
     },
-    "espree": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
-      "dev": true,
-      "requires": {
-        "acorn": "5.2.1",
-        "acorn-jsx": "3.0.1"
-      }
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esquery": {
@@ -530,7 +551,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -630,6 +651,19 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-1.1.0.tgz",
+      "integrity": "sha1-VMIbCAGSsW2Yd3ecW7gWZudyNl8="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -641,7 +675,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -741,13 +775,13 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -769,13 +803,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -830,6 +863,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -847,8 +885,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -967,7 +1004,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -1015,6 +1052,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "5.0.1",
+        "minimist": "1.2.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
+      }
     },
     "node-parquet": {
       "version": "0.2.6",
@@ -1129,7 +1177,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -1141,8 +1189,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -1170,7 +1217,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -1181,10 +1227,16 @@
         "util-deprecate": "1.0.2"
       }
     },
+    "regexpp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz",
+      "integrity": "sha1-2FfDp0Hc4HXChI3LAZoKl1sZDUM=",
+      "dev": true
+    },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -1381,7 +1433,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -1393,6 +1445,14 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.0"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {
@@ -1429,7 +1489,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -1440,7 +1500,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -1482,7 +1541,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
         "ajv": "5.5.0",
@@ -1505,10 +1564,19 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -1560,8 +1628,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.1.0",
@@ -1586,7 +1653,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -1612,6 +1679,11 @@
       "requires": {
         "mkdirp": "0.5.1"
       }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.0",
   "dependencies": {
     "bluebird": "^3.5.1",
+    "csv-parser": "^1.12.0",
     "node-parquet": "^0.2.6",
-    "request": "^2.83.0",
+    "request": "^2.85.0",
     "request-promise": "^4.2.2",
     "s3": "^4.4.0"
   },
   "devDependencies": {
-    "eslint": "^4.12.1",
+    "eslint": "^4.19.0",
     "eslint-plugin-fxa": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Between 14-Mar-2018 and 19-Mar-2018, the content server instances ran out of disk IOPS because of increased logging caused by heavy traffic from Fx 59. One outcome of this is that we're missing a bunch of events in Amplitude. In order to backfill the lost events, this PR adds a new script that recreates Amplitude events from flow events, which we happen to have lying around in S3.

The transformation process is not perfect. For instance, we don't have the `device_id` property in the flow data, and it's used to calculate the `insert_id` when present. Since the `insert_id` is what Amplitude uses to deduplicate events, this is a pretty important caveat.

So, in order for this script to be useful, we need one of the following things to be true:

* We know that the events that made it to Amplitude did not contain a `device_id`, ensuring that the recreated events will have a consistent `insert_id`. My hunch is that this is true for many content server events but not all, although I can't be certain.

* We've been able to somehow delete from Amplitude all content server events for the days that we are re-importing. Seems tricky, although maybe it's possible if we ask them.

* We are able to deduplicate the events ourselves pre-import, by comparing the uid, timestamp and event type for each event to the events that made it in to Amplitude. This one is doable, but the work is for a different script.