### PR TITLE
fix(pubsub): Try options to do things

### DIFF
--- a/pubsub/package-lock.json
+++ b/pubsub/package-lock.json
@@ -453,10 +453,25 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "fast-redact": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.5.0.tgz",
+      "integrity": "sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
     "fast-text-encoding": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
       "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
+    },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1380,6 +1395,24 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
+    "pino": {
+      "version": "5.12.6",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.12.6.tgz",
+      "integrity": "sha512-LM5ug2b27uymIIkaBw54ncF+9DSf8S4z1uzw+Y5I94dRu3Z+lFuB13j0kg1InAeyxy+CsLGnWHKy9+zgTreFOg==",
+      "requires": {
+        "fast-redact": "^1.4.4",
+        "fast-safe-stringify": "^2.0.6",
+        "flatstr": "^1.0.9",
+        "pino-std-serializers": "^2.3.0",
+        "quick-format-unescaped": "^3.0.2",
+        "sonic-boom": "^0.7.3"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -1426,6 +1459,11 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
+      "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA=="
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -1514,6 +1552,14 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+    },
+    "sonic-boom": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.4.tgz",
+      "integrity": "sha512-8JRAJg0RxZtFLQMxolwETvWd2JSlH3ZGo/Z4xPxMbpqF14xCgVYPVeFCFOR3zyr3pcfG82QDVj6537Sx5ZWdNw==",
+      "requires": {
+        "flatstr": "^1.0.9"
+      }
     },
     "split-array-stream": {
       "version": "2.0.0",

--- a/pubsub/package.json
+++ b/pubsub/package.json
@@ -6,6 +6,7 @@
     "async": "^2.6.2",
     "check-types": "^8.0.2",
     "lookup-dns-cache": "^2.1.0",
+    "pino": "^5.12.6",
     "request": "^2.88.0",
     "request-promise": "^4.2.4"
   },


### PR DESCRIPTION
Needs to be merged after #94 .

The reason messages stayed on each process forever was that `flowControl.maxExtension` was set to `Infinity` [by default](https://github.com/googleapis/nodejs-pubsub/issues/637). This patch sets it to a reasonable value, and also smears nacks() over a random 5 minute period to avoid rate-limiting kicking in. So far this has been working pretty well!