### PR TITLE
Add support for routing 'identify' events to the batch API.

### DIFF
--- a/pubsub/index.js
+++ b/pubsub/index.js
@@ -302,15 +302,31 @@ function splitIdentifyPayload (properties) {
 }
 
 function sendPayload (payload, endpoint, key) {
-  return request(endpoint, {
-    method: 'POST',
-    lookup,
-    formData: {
-      api_key: AMPLITUDE_API_KEY,
-      [key]: JSON.stringify(payload.map(item => ({ ...item, _insert_id: undefined })))
-    },
-    timeout: 5 * 1000
-  })
+  if (endpoint === ENDPOINTS.BATCH_API) {
+    return request(endpoint, {
+      method: 'POST',
+      lookup,
+      json: true,
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: {
+        api_key: AMPLITUDE_API_KEY,
+        [key]: JSON.stringify(payload.map(item => ({ ...item, _insert_id: undefined })))
+      },
+      timeout: 5 * 1000 // TODO: should this be configurable?
+    })
+  } else {
+    return request(endpoint, {
+      method: 'POST',
+      lookup,
+      formData: {
+        api_key: AMPLITUDE_API_KEY,
+        [key]: JSON.stringify(payload.map(item => ({ ...item, _insert_id: undefined })))
+      },
+      timeout: 5 * 1000
+    })
+  }
 }
 
 function clearMessages (payload, action, forceAction = false) {

--- a/pubsub/index.js
+++ b/pubsub/index.js
@@ -182,6 +182,7 @@ function processMessage (cargo, message) {
   //  and Math.random values from 0.75 to 1 => use identify API.
   if (identify) {
     if (Math.floor(Math.random() * 100) < BATCH_API_PERCENTAGE) {
+      identify.event_type = "$identify";
       cargo.batch.push(identify);
     } else {
       cargo.identify.push(identify);


### PR DESCRIPTION
This change allows the 'identify' amplitude events to be split between
the identify API and the batch API.

The BATCH_API_PERCENTAGE env var (int 0 - 100, default 75) is used to
decide which API to use to handle a particular event.

Other new config values added in this patch:

* BATCH_API_MAX_EVENTS_PER_BATCH, number of events per batch API
submission (default 10)

* BATCH_API_WORKER_COUNT, number of batch API queue workers per
fxa-amplitude-send instance (default 1)

Fixes #107.

I'm working on unit tests that can run locally, even if node-parquet doesn't install on MacOS Sierra 🙄, but there's no reason to block on that.